### PR TITLE
Remove support for taint checking and untainting

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -39,7 +39,7 @@ module Liquid
     end
 
     def escape(input)
-      CGI.escapeHTML(input.to_s).untaint unless input.nil?
+      CGI.escapeHTML(input.to_s) unless input.nil?
     end
     alias_method :h, :escape
 

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -84,11 +84,7 @@ module Liquid
         context.invoke(filter_name, output, *filter_args)
       end
 
-      obj = context.apply_global_filter(obj)
-
-      taint_check(context, obj)
-
-      obj
+      context.apply_global_filter(obj)
     end
 
     private

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -112,32 +112,6 @@ class DropsTest < Minitest::Test
     assert_equal '  ', tpl.render!('product' => ProductDrop.new)
   end
 
-  def test_rendering_raises_on_tainted_attr
-    with_taint_mode(:error) do
-      tpl = Liquid::Template.parse('{{ product.user_input }}')
-      assert_raises TaintedError do
-        tpl.render!('product' => ProductDrop.new)
-      end
-    end
-  end
-
-  def test_rendering_warns_on_tainted_attr
-    with_taint_mode(:warn) do
-      tpl = Liquid::Template.parse('{{ product.user_input }}')
-      context = Context.new('product' => ProductDrop.new)
-      tpl.render!(context)
-      assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
-      assert_equal "variable 'product.user_input' is tainted and was not escaped", context.warnings.first.to_s(false)
-    end
-  end
-
-  def test_rendering_doesnt_raise_on_escaped_tainted_attr
-    with_taint_mode(:error) do
-      tpl = Liquid::Template.parse('{{ product.user_input | escape }}')
-      tpl.render!('product' => ProductDrop.new)
-    end
-  end
-
   def test_drop_does_only_respond_to_whitelisted_methods
     assert_equal "", Liquid::Template.parse("{{ product.inspect }}").render!('product' => ProductDrop.new)
     assert_equal "", Liquid::Template.parse("{{ product.pretty_inspect }}").render!('product' => ProductDrop.new)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,14 +69,6 @@ module Minitest
       Liquid::Strainer.class_variable_set(:@@global_strainer, original_global_strainer)
     end
 
-    def with_taint_mode(mode)
-      old_mode = Liquid::Template.taint_mode
-      Liquid::Template.taint_mode = mode
-      yield
-    ensure
-      Liquid::Template.taint_mode = old_mode
-    end
-
     def with_error_mode(mode)
       old_mode = Liquid::Template.error_mode
       Liquid::Template.error_mode = mode


### PR DESCRIPTION
Ruby has deprecated support for taint checking from Ruby 2.7.
ref: https://bugs.ruby-lang.org/issues/16131