### PR TITLE
Reduce allocations from `Liquid::Variable#render`

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -108,16 +108,20 @@ module Liquid
       result
     end
 
+    EMPTY_ARRAY = [].freeze
+    private_constant :EMPTY_ARRAY
+
     def evaluate_filter_expressions(context, filter_args, filter_kwargs)
+      return EMPTY_ARRAY if filter_args.empty? && !filter_kwargs
+
       parsed_args = filter_args.map { |expr| context.evaluate(expr) }
-      if filter_kwargs
-        parsed_kwargs = {}
-        filter_kwargs.each do |key, expr|
-          parsed_kwargs[key] = context.evaluate(expr)
-        end
-        parsed_args << parsed_kwargs
+      return parsed_args unless filter_kwargs
+
+      parsed_kwargs = {}
+      filter_kwargs.each do |key, expr|
+        parsed_kwargs[key] = context.evaluate(expr)
       end
-      parsed_args
+      parsed_args << parsed_kwargs
     end
 
     def taint_check(context, obj)


### PR DESCRIPTION
Return a predefined constant instead of unnecessarily generating a new object on each call.
Since the returned object is intended to be an argument to the splat operator, being frozen doesn't matter.