### PR TITLE
Render nodes into an array first

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -44,7 +44,7 @@ module Liquid
       context.stack do
         execute_else_block = true
 
-        output = +''
+        output = []
         @blocks.each do |block|
           if block.else?
             return block.attachment.render(context) if execute_else_block
@@ -53,7 +53,7 @@ module Liquid
             output << block.attachment.render(context)
           end
         end
-        output
+        output.join
       end
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -155,7 +155,7 @@ module Liquid
       for_stack = context.registers[:for_stack] ||= []
       length = segment.length
 
-      result = +''
+      result = []
 
       context.stack do
         loop_vars = Liquid::ForloopDrop.new(@name, length, for_stack[-1])
@@ -182,7 +182,7 @@ module Liquid
         end
       end
 
-      result
+      result.join
     end
 
     def set_attribute(key, expr)

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -32,7 +32,7 @@ module Liquid
 
       cols = context.evaluate(@attributes['cols']).to_i
 
-      result = +"<tr class=\"row1\">\n"
+      result = ["<tr class=\"row1\">\n"]
       context.stack do
         tablerowloop = Liquid::TablerowloopDrop.new(length, cols)
         context['tablerowloop'] = tablerowloop
@@ -40,7 +40,9 @@ module Liquid
         collection.each do |item|
           context[@variable_name] = item
 
-          result << "<td class=\"col#{tablerowloop.col}\">" << super << '</td>'
+          result << "<td class=\"col#{tablerowloop.col}\">"
+          result << super
+          result << '</td>'
 
           if tablerowloop.col_last && !tablerowloop.last
             result << "</tr>\n<tr class=\"row#{tablerowloop.row + 1}\">"
@@ -50,7 +52,7 @@ module Liquid
         end
       end
       result << "</tr>\n"
-      result
+      result.join
     end
 
     class ParseTreeVisitor < Liquid::ParseTreeVisitor


### PR DESCRIPTION
Gauge memory usage by using an array to collect all rendered output and stringify via `Array#join`.