### PR TITLE
Stash `exception_renderer` lambda in a constant

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -42,6 +42,8 @@ module Liquid
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 
+  RAISE_EXCEPTION_LAMBDA = ->(_e) { raise }
+
   singleton_class.send(:attr_accessor, :cache_classes)
   self.cache_classes = true
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -31,7 +31,7 @@ module Liquid
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
-        self.exception_renderer = ->(e) { raise }
+        self.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
       end
 
       @interrupts = []

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -29,10 +29,7 @@ module Liquid
 
       @this_stack_used = false
 
-      self.exception_renderer = Template.default_exception_renderer
-      if rethrow_errors
-        self.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
-      end
+      self.exception_renderer = rethrow_errors ? Liquid::RAISE_EXCEPTION_LAMBDA : Template.default_exception_renderer
 
       @interrupts = []
       @filters = []

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -169,9 +169,7 @@ module Liquid
         when Liquid::Context
           c = args.shift
 
-          if @rethrow_errors
-            c.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
-          end
+          c.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA if @rethrow_errors
 
           c
         when Liquid::Drop

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -170,7 +170,7 @@ module Liquid
           c = args.shift
 
           if @rethrow_errors
-            c.exception_renderer = ->(e) { raise }
+            c.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
           end
 
           c


### PR DESCRIPTION
In order to avoid allocating it for every instance of `Liquid::Context` and `Liquid::Template`